### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-faker==8.11.0
+faker==28.1.0
 robotframework
 wrapt


### PR DESCRIPTION
robotframework-faker is behind bij 13 major releases. This (also) causes critical security alerts for code quality scanners.

Release 19.0.0 drops support for:
Python 3.7
32 bit systems.

v18.13.0 Would still have Python 3.7 and 32 bit support if that is a breaking change. 

Otherwise I can't directly see any reason to not update this to v28.1.0

Making this a major release for robotframework-faker v6.0.0 would be appreciated